### PR TITLE
Add IndieAuth and micropub discovery to trip micropub settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,29 @@ Compass is a GPS tracking server that stores data in [flat files](https://github
 
 ![mapview](screenshot-mapview.jpg)
 
+## Requirements
+
+* PHP 5.5 or above
+* MySQL (for storing user accounts and lists of databases, not for storing the actual location data)
+
+### PHP extensions
+
+You'll need to make sure the following PHP extensions are installed. Typically these are installed using the package manager of your operating system.
+
+* curl
+* mbstring
+* phpunit
+* zip
+* unzip
+
+### Optional
+
+* Redis (for the job queue, can use MySQL instead)
+
+
 ## Setup
+
+Compass is built using the [Lumen framework](https://lumen.laravel.com/). If you have any trouble getting started, you can refer to the [Lumen documentation](https://lumen.laravel.com/docs/5.1) for tips that may have been skipped or assumed in these instructions.
 
 In the `compass` directory, copy `.env.example` to `.env` and fill in the details. Install the dependencies with composer.
 
@@ -27,7 +49,7 @@ try_files $uri /index.php?$args;
 ```
 
 ### Job Queue
-For the job queue you will either need to have one of the supported options by Luman. The two most likely options are an SQL database or Redis.
+For the job queue you will either need to have one of the supported options by Lumen. The two most likely options are an SQL database or Redis.
 You can find other supported options [here](https://lumen.laravel.com/docs/5.1/queues#introduction)
 
 If you're using the database queue driver (`QUEUE_DRIVER=database` defined in `.env`), you'll need to create the migration for that table:

--- a/compass/.env.example
+++ b/compass/.env.example
@@ -1,14 +1,18 @@
 # Where you've installed Compass
 BASE_URL=https://compass.example.com/
 
-# Atlas is used for geocoding trips
+# Atlas is used for geocoding trips.
+# You can use mine or install your own.
 # Source code: https://github.com/aaronpk/Atlas
 ATLAS_BASE=https://atlas.p3k.io/
 
-# Make sure the web server or PHP process can write here
+# This is where the location data will be saved.
+# Compass will create a folder for each "database" you create after you log in.
+# Make sure the web server or PHP process can write here.
 STORAGE_DIR=/var/compass/data
 
-# Set APP_KEY to a 32 character string
+# Set APP_KEY to a 32 character string. This is used to encrypt session data.
+# You can generate a string using the command `php artisan key:generate`
 APP_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Define your database connection
@@ -29,10 +33,14 @@ SESSION_LIFETIME=500000
 QUEUE_DRIVER=database
 # QUEUE_DRIVER=redis
 
+# This is how Compass signs users in. You can leave it set to the default, and
+# you'll be redirected there to authenticate as your domain name.
+# You can also run your own instance, or even point it to your own website
+# if it supports the IndieAuth protocol https://indieweb.org/indieauth-for-login
 DEFAULT_AUTH_ENDPOINT=https://indieauth.com/auth
 
 APP_ENV=local
-APP_DEBUG=true
+APP_DEBUG=false
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/compass/.env.example
+++ b/compass/.env.example
@@ -33,6 +33,8 @@ SESSION_LIFETIME=500000
 QUEUE_DRIVER=database
 # QUEUE_DRIVER=redis
 
+CACHE_DRIVER=redis
+
 # This is how Compass signs users in. You can leave it set to the default, and
 # you'll be redirected there to authenticate as your domain name.
 # You can also run your own instance, or even point it to your own website

--- a/compass/app/Console/Commands/GenerateKey.php
+++ b/compass/app/Console/Commands/GenerateKey.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Console\Commands;
+use Illuminate\Console\Command;
+
+class GenerateKey extends Command {
+
+  protected $signature = 'key:generate';
+  protected $description = 'Generate a random key for APP_KEY';
+
+  public function handle() {
+    $key = bin2hex(random_bytes(16));
+    $this->line('Below is a random string you can use for APP_KEY in the .env file');
+    $this->info($key);
+  }
+
+}

--- a/compass/app/Console/Kernel.php
+++ b/compass/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
       'App\Console\Commands\TestTrip',
       'App\Console\Commands\CleanFile',
+      'App\Console\Commands\GenerateKey'
     ];
 
     /**

--- a/compass/app/Http/Controllers/Api.php
+++ b/compass/app/Http/Controllers/Api.php
@@ -269,6 +269,10 @@ class Api extends BaseController
       }
     }
 
+    if($request->input('current')) {
+      $last_location = $request->input('current');
+    }
+
     $response = [
       'result' => 'ok', 
       'saved' => $num, 
@@ -289,7 +293,7 @@ class Api extends BaseController
 
       // Notify subscribers that new data is available
       if($db->ping_urls) {
-        $job = (new NotifyOfNewLocations($db->id))->onQueue('compass');
+        $job = (new NotifyOfNewLocations($db->id, $last_location))->onQueue('compass');
         $this->dispatch($job);
       }
     }

--- a/compass/app/Http/routes.php
+++ b/compass/app/Http/routes.php
@@ -10,6 +10,9 @@ $app->get('/auth/logout', 'IndieAuth@logout');
 $app->get('/map/{name:[A-Za-z0-9]+}', 'Controller@map');
 $app->get('/settings/{name:[A-Za-z0-9]+}', 'Controller@settings');
 $app->post('/settings/{name:[A-Za-z0-9]+}', 'Controller@updateSettings');
+$app->post('/settings/{name:[A-Za-z0-9]+}/auth/start', 'Controller@micropubStart');
+$app->get('/settings/{name:[A-Za-z0-9]+}/auth/callback', 'Controller@micropubCallback');
+$app->get('/settings/{name:[A-Za-z0-9]+}/auth/remove', 'Controller@removeMicropub');
 $app->post('/database/create', 'Controller@createDatabase');
 
 $app->get('/api/query', 'Api@query');

--- a/compass/app/Jobs/NotifyOfNewLocations.php
+++ b/compass/app/Jobs/NotifyOfNewLocations.php
@@ -1,8 +1,7 @@
 <?php
 namespace App\Jobs;
 
-use DB;
-use Log;
+use DB, Log;
 use App\Jobs\Job;
 use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -11,22 +10,30 @@ use DateTime, DateTimeZone;
 class NotifyOfNewLocations extends Job implements SelfHandling, ShouldQueue
 {
   private $_dbid;
+  private $_last_location;
 
-  public function __construct($dbid) {
+  public function __construct($dbid, $last_location) {
     $this->_dbid = $dbid;
+    $this->_last_location = $last_location;
   }
 
   public function handle() {
     $db = DB::table('databases')->where('id','=',$this->_dbid)->first();
     $urls = preg_split('/\s+/', $db->ping_urls);
     foreach($urls as $url) {
-      $ch = curl_init($url);
-      curl_setopt($ch, CURLOPT_POST, true);
-      curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-        'url' => env('BASE_URL').'api/last?token='.$db->read_token.'&geocode=1'
-      ]));
-      curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-      curl_exec($ch);
+      if(trim($url)) {
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+          'Content-Type: application/json',
+          'Authorization: Bearer '.$db->read_token,
+          'Compass-Url: '.env('BASE_URL').'api/last?token='.$db->read_token.'&geocode=1'
+        ]);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($this->_last_location));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_exec($ch);
+        Log::info("Notifying ".$url." with current location");
+      }
     }
   }
 }

--- a/compass/app/Jobs/TripComplete.php
+++ b/compass/app/Jobs/TripComplete.php
@@ -238,7 +238,9 @@ class TripComplete extends Job implements SelfHandling, ShouldQueue
     $response = curl_exec($ch);
 
     Log::info("Done!");
-    Log::info($response);
+    if(preg_match('/Location: (.+)/', $response, $match)) {
+      Log::info($match[1]);
+    }
 
     // echo "========\n";
     // echo $response."\n========\n";

--- a/compass/public/assets/events.js
+++ b/compass/public/assets/events.js
@@ -3,6 +3,12 @@ function collectEventSeries(data) {
   var events = data.events;
 
   var series = {
+    "application_launched_with_location": {
+      name: "Launched with Location",
+      color: '#42C093',
+      y: 90,
+      data: []
+    },
     "visit": {
       name: "Visit",
       type: 'scatter',
@@ -55,11 +61,13 @@ function collectEventSeries(data) {
   };
 
   for(var i=0; i<events.length; i++) {
-    series[events[i].properties.action].data.push({
-      x: new Date(events[i].properties.unixtime*1000), 
-      y: series[events[i].properties.action].y,
-      location: (events[i].geometry ? events[i].geometry.coordinates : null)
-    });
+    if(series[events[i].properties.action]) {
+      series[events[i].properties.action].data.push({
+        x: new Date(events[i].properties.unixtime*1000), 
+        y: series[events[i].properties.action].y,
+        location: (events[i].geometry ? events[i].geometry.coordinates : null)
+      });
+    }
   }
   
   var response = [];

--- a/compass/resources/views/index.blade.php
+++ b/compass/resources/views/index.blade.php
@@ -2,9 +2,10 @@
 
 @section('content')
 
-<div class="splash">
+<div class="splash h-x-app">
 
-  <div class="logo"><img src="/assets/compass.svg" width="200"></div>
+  <a class="p-name u-url" href="" style="display: none;">Compass</a>
+  <div class="logo"><img src="/assets/compass.svg" width="200" class="u-logo"></div>
 
   <form action="/auth/start" method="post" class="ui form login" style="margin-top: 40px;">
     <div class="ui action input">

--- a/compass/resources/views/settings.blade.php
+++ b/compass/resources/views/settings.blade.php
@@ -98,7 +98,7 @@
       <button type="submit" class="ui button primary">Connect</button>
     </form>
     @else
-      <form action="/settings/{{ $database->name }}/auth/remove" method="post" class="ui form">
+      <form action="/settings/{{ $database->name }}/auth/remove" method="get" class="ui form">
         <div class="field">
           <p>You are currently posting to <strong>{{$database->micropub_endpoint}}</strong>. Any trips that are written to this database will be sent to that endpoint as well.</p>
         </div>

--- a/compass/resources/views/settings.blade.php
+++ b/compass/resources/views/settings.blade.php
@@ -86,22 +86,26 @@
 
   <h2>Realtime Micropub Export</h2>
 
-  <p>Enter a Micropub endpoint and token below and any trips that are written to this database will be sent to the endpoint as well.</p>
-
   <div class="panel">
-    <form action="/settings/{{ $database->name }}" method="post" class="ui form">
+    @if (empty($database->micropub_token))
+    <p>Authorize Compass with a micropub endpoint and any trips that are written to this database will be sent to that endpoint as well.</p>
+    <form action="/settings/{{ $database->name }}/auth/start" method="post" class="ui form">
       <div class="field">
-        <label for="micropub_endpoint">Micropub Endpoint</label>
-        <input name="micropub_endpoint" type="url" placeholder="http://example.com/micropub" class="pure-input-1" value="{{ $database->micropub_endpoint }}">
+        <label for="micropub_endpoint">web sign-in</label>
+        <input name="me" type="url" placeholder="http://example.com/" class="pure-input-1" value="">
       </div>
 
-      <div class="field">
-        <label for="micropub_token">Access Token</label>
-        <input name="micropub_token" type="text" placeholder="" class="pure-input-1" value="{{ $database->micropub_token }}">
-      </div>
-
-      <button type="submit" class="ui button primary">Save</button>
+      <button type="submit" class="ui button primary">Connect</button>
     </form>
+    @else
+      <form action="/settings/{{ $database->name }}/auth/remove" method="post" class="ui form">
+        <div class="field">
+          <p>You are currently posting to <strong>{{$database->micropub_endpoint}}</strong>. Any trips that are written to this database will be sent to that endpoint as well.</p>
+        </div>
+
+        <button type="submit" class="ui button primary">Disconnect</button>
+      </form>
+    @endif
   </div>
 
   <br>


### PR DESCRIPTION
Replaced the open text fields of micropub endpoint and access token with IndieAuth flow that allows user to provide their url, to authenticate via IndieAuth and have Compass retrieve a properly scoped access token and do micropub endpoint discovery on the url.

<img width="528" alt="screen shot 2017-10-17 at 1 39 16 pm" src="https://user-images.githubusercontent.com/786014/31679981-dc2d078a-b340-11e7-991c-5a54e633c3d4.png">

When you are logged in, user is presented with their micropub endpoint and a disconnect button

<img width="518" alt="screen shot 2017-10-17 at 12 01 59 pm" src="https://user-images.githubusercontent.com/786014/31679984-e106eaf0-b340-11e7-8d3d-4230ff2e85ef.png">
