### PR TITLE
Add IndieAuth and micropub discovery to trip micropub settings

### DIFF
--- a/compass/app/Http/routes.php
+++ b/compass/app/Http/routes.php
@@ -10,6 +10,9 @@ $app->get('/auth/logout', 'IndieAuth@logout');
 $app->get('/map/{name:[A-Za-z0-9]+}', 'Controller@map');
 $app->get('/settings/{name:[A-Za-z0-9]+}', 'Controller@settings');
 $app->post('/settings/{name:[A-Za-z0-9]+}', 'Controller@updateSettings');
+$app->post('/settings/{name:[A-Za-z0-9]+}/auth/start', 'Controller@micropubStart');
+$app->get('/settings/{name:[A-Za-z0-9]+}/auth/callback', 'Controller@micropubCallback');
+$app->get('/settings/{name:[A-Za-z0-9]+}/auth/remove', 'Controller@removeMicropub');
 $app->post('/database/create', 'Controller@createDatabase');
 
 $app->get('/api/query', 'Api@query');

--- a/compass/resources/views/settings.blade.php
+++ b/compass/resources/views/settings.blade.php
@@ -86,22 +86,26 @@
 
   <h2>Realtime Micropub Export</h2>
 
-  <p>Enter a Micropub endpoint and token below and any trips that are written to this database will be sent to the endpoint as well.</p>
-
   <div class="panel">
-    <form action="/settings/{{ $database->name }}" method="post" class="ui form">
+    @if (empty($database->micropub_token))
+    <p>Authorize Compass with a micropub endpoint and any trips that are written to this database will be sent to that endpoint as well.</p>
+    <form action="/settings/{{ $database->name }}/auth/start" method="post" class="ui form">
       <div class="field">
-        <label for="micropub_endpoint">Micropub Endpoint</label>
-        <input name="micropub_endpoint" type="url" placeholder="http://example.com/micropub" class="pure-input-1" value="{{ $database->micropub_endpoint }}">
+        <label for="micropub_endpoint">web sign-in</label>
+        <input name="me" type="url" placeholder="http://example.com/" class="pure-input-1" value="">
       </div>
 
-      <div class="field">
-        <label for="micropub_token">Access Token</label>
-        <input name="micropub_token" type="text" placeholder="" class="pure-input-1" value="{{ $database->micropub_token }}">
-      </div>
-
-      <button type="submit" class="ui button primary">Save</button>
+      <button type="submit" class="ui button primary">Connect</button>
     </form>
+    @else
+      <form action="/settings/{{ $database->name }}/auth/remove" method="get" class="ui form">
+        <div class="field">
+          <p>You are currently posting to <strong>{{$database->micropub_endpoint}}</strong>. Any trips that are written to this database will be sent to that endpoint as well.</p>
+        </div>
+
+        <button type="submit" class="ui button primary">Disconnect</button>
+      </form>
+    @endif
   </div>
 
   <br>


### PR DESCRIPTION
Replaced the open text fields of micropub endpoint and access token with IndieAuth flow that allows user to provide their url, to authenticate via IndieAuth and have Compass retrieve a properly scoped access token and do micropub endpoint discovery on the url.

<img width="528" alt="screen shot 2017-10-17 at 1 39 16 pm" src="https://user-images.githubusercontent.com/786014/31679981-dc2d078a-b340-11e7-991c-5a54e633c3d4.png">

When you are logged in, user is presented with their micropub endpoint and a disconnect button

<img width="518" alt="screen shot 2017-10-17 at 12 01 59 pm" src="https://user-images.githubusercontent.com/786014/31679984-e106eaf0-b340-11e7-8d3d-4230ff2e85ef.png">
