### PR TITLE
Updated .env.example to show that STORAGE_DIR must end with /

### DIFF
--- a/compass/.env.example
+++ b/compass/.env.example
@@ -6,10 +6,10 @@ BASE_URL=https://compass.example.com/
 # Source code: https://github.com/aaronpk/Atlas
 ATLAS_BASE=https://atlas.p3k.io/
 
-# This is where the location data will be saved.
+# This is where the location data will be saved, MAKE SURE PATH ENDS WITH /
 # Compass will create a folder for each "database" you create after you log in.
 # Make sure the web server or PHP process can write here.
-STORAGE_DIR=/var/compass/data
+STORAGE_DIR=/var/compass/data/
 
 # Set APP_KEY to a 32 character string. This is used to encrypt session data.
 # You can generate a string using the command `php artisan key:generate`


### PR DESCRIPTION
STORAGE_DIR env variable must end with /, otherwise app tries to write to different directory

Original .env.example gave incorrect example of write path, app tried to write to .../datadbname/ directory instead of .../data/dbname